### PR TITLE
APA102/DotStar LEDs 

### DIFF
--- a/APA102.py
+++ b/APA102.py
@@ -3,26 +3,29 @@ from machine import Pin, SPI
 
 class APA102:
 
-    values = [
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-    ]
+    #XXX not used yet - do we need it?
+    ORDER = (0, 1, 2, 3)
 
-    def __init__(self, spi, n):
-        super().__init__()
+    leds = []
+
+    def __init__(self, spi, n=4):
         self.spi = spi
         self.spi.init(baudrate=4000000)
         self.n = n
+        # init led value matrix
+        for i in range(n):
+            self.leds.append([0, 0, 0, 0])
 
     def __setitem__(self, index, color):
-        # color is 4d array (first item is brightness)
-        self.values[index] = color
+        # color is 4d array (last item is brightness)
+        # brightness is 5Bit
+        if not (0 <= color[3] <= 31):
+            raise ValueError("Invalid brightness! Values: 0(off) to 31(full)")
+        self.leds[index] = color
         self.write()
 
     def __getitem__(self, index):
-        return self.values[index]
+        return self.leds[index]
 
     def fill(self, color):
         for i in range(self.n):
@@ -38,28 +41,28 @@ class APA102:
         self._send_byte(bytearray([0xFF] * 4))
 
     def reset(self):
-        # TODO: set `values` to zero
+        # TODO: set `leds` to zero
         self._start_frame()
         for i in range(4):
             self._send_byte(bytearray([0xE0] + [0] * 3))
         self._end_frame()
 
     def _send_single(self, color):
-        # color is 4d array (first item is brightness)
-        self._send_byte(bytearray([0xE0 + color[0]] + [color[1]] + [color[2]] + [color[3]]))
+        # default: color is 4d array (last item is brightness)
+        self._send_byte(bytearray([0xE0 + color[3]] + [color[2]] + [color[1]] + [color[0]]))
 
     def write(self):
         self._start_frame()
 
-        for i in range(len(self.values)):
-            self._send_single(self.values[i])
+        for i in range(len(self.leds)):
+            self._send_single(self.leds[i])
 
         self._end_frame()
 
 
 def main():
     led = APA102(SPI(2, sck=Pin(13), mosi=Pin(4), miso=Pin(12)), n=4)
-    led[0] = [255, 255, 0, 0]
-    led[1] = [255, 0, 255, 0]
-    led[2] = [255, 0, 0, 255]
-    led[3] = [255, 255, 255, 0]
+    led[0] = [255, 0, 0, 31]
+    led[1] = [0, 255, 0, 31]
+    led[2] = [0, 0, 255, 31]
+    led[3] = [255, 255, 0, 31]

--- a/APA102.py
+++ b/APA102.py
@@ -1,0 +1,65 @@
+from machine import Pin, SPI
+
+
+class APA102:
+
+    values = [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+
+    def __init__(self, spi, n):
+        super().__init__()
+        self.spi = spi
+        self.spi.init(baudrate=4000000)
+        self.n = n
+
+    def __setitem__(self, index, color):
+        # color is 4d array (first item is brightness)
+        self.values[index] = color
+        self.write()
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def fill(self, color):
+        for i in range(self.n):
+            self[i] = color
+
+    def _send_byte(self, data):
+        self.spi.write(data)
+
+    def _start_frame(self):
+        self._send_byte(bytearray([0] * 4))
+
+    def _end_frame(self):
+        self._send_byte(bytearray([0xFF] * 4))
+
+    def reset(self):
+        # TODO: set `values` to zero
+        self._start_frame()
+        for i in range(4):
+            self._send_byte(bytearray([0xE0] + [0] * 3))
+        self._end_frame()
+
+    def _send_single(self, color):
+        # color is 4d array (first item is brightness)
+        self._send_byte(bytearray([0xE0 + color[0]] + [color[1]] + [color[2]] + [color[3]]))
+
+    def write(self):
+        self._start_frame()
+
+        for i in range(len(self.values)):
+            self._send_single(self.values[i])
+
+        self._end_frame()
+
+
+def main():
+    led = APA102(SPI(2, sck=Pin(13), mosi=Pin(4), miso=Pin(12)), n=4)
+    led[0] = [255, 255, 0, 0]
+    led[1] = [255, 0, 255, 0]
+    led[2] = [255, 0, 0, 255]
+    led[3] = [255, 255, 255, 0]

--- a/the_pad/apa102.py
+++ b/the_pad/apa102.py
@@ -1,6 +1,5 @@
 from machine import Pin, SPI
 
-
 class APA102:
 
     #XXX not used yet - do we need it?
@@ -20,7 +19,7 @@ class APA102:
         # color is 4d array (last item is brightness)
         # brightness is 5Bit
         if not (0 <= color[3] <= 31):
-            raise ValueError("Invalid brightness! Values: 0(off) to 31(full)")
+            raise ValueError("Invalid brightness! 0(off) to 31(full)")
         self.leds[index] = color
         self.write()
 

--- a/the_pad/apa102.py
+++ b/the_pad/apa102.py
@@ -1,8 +1,6 @@
-from machine import Pin, SPI
-
 class APA102:
 
-    #XXX not used yet - do we need it?
+    #XXX not used yet - do we need it? See micropython code for ESP8266.
     ORDER = (0, 1, 2, 3)
 
     leds = []
@@ -21,7 +19,6 @@ class APA102:
         if not (0 <= color[3] <= 31):
             raise ValueError("Invalid brightness! 0(off) to 31(full)")
         self.leds[index] = color
-        self.write()
 
     def __getitem__(self, index):
         return self.leds[index]
@@ -57,11 +54,3 @@ class APA102:
             self._send_single(self.leds[i])
 
         self._end_frame()
-
-
-def main():
-    led = APA102(SPI(2, sck=Pin(13), mosi=Pin(4), miso=Pin(12)), n=4)
-    led[0] = [255, 0, 0, 31]
-    led[1] = [0, 255, 0, 31]
-    led[2] = [0, 0, 255, 31]
-    led[3] = [255, 255, 0, 31]

--- a/the_pad/demos/apa102_strip.py
+++ b/the_pad/demos/apa102_strip.py
@@ -1,0 +1,52 @@
+import apa102, time
+from machine import SPI, Pin
+
+# strip with 4 LEDs
+spi = SPI(2, sck=Pin(13), mosi=Pin(4), miso=Pin(12))
+strip = apa102.APA102(spi, 4)
+
+brightness = 1  # 0 is off, 1 is dim, 31 is max
+
+# Helper for converting 0-255 offset to a colour tuple
+def wheel(offset, brightness):
+    # The colours are a transition r - g - b - back to r
+    offset = 255 - offset
+    if offset < 85:
+        return (255 - offset * 3, 0, offset * 3, brightness)
+    if offset < 170:
+        offset -= 85
+        return (0, offset * 3, 255 - offset * 3, brightness)
+    offset -= 170
+    return (offset * 3, 255 - offset * 3, 0, brightness)
+
+# Demo 1: RGB RGB RGB
+red = 0xff0000
+green = red >> 8
+blue = red >> 16
+for i in range(strip.n):
+    colour = red >> (i % 3) * 8
+    strip[i] = ((colour & red) >> 16, (colour & green) >> 8, (colour & blue), brightness)
+strip.write()
+
+# Demo 2: Show all colours of the rainbow
+for i in range(strip.n):
+    strip[i] = wheel((i * 256 // strip.n) % 255, brightness)
+strip.write()
+
+# Demo 3: Fade all pixels together through rainbow colours, offset each pixel
+for r in range(5):
+    for n in range(256):
+        for i in range(strip.n):
+            strip[i] = wheel(((i * 256 // strip.n) + n) & 255, brightness)
+        strip.write()
+    time.sleep_ms(25)
+
+# Demo 4: Same colour, different brightness levels
+for b in range(31,-1,-1):
+    strip[0] = (255, 153, 0, b)
+    strip.write()
+    time.sleep_ms(250)
+
+# End: Turn off all the LEDs
+strip.fill((0, 0, 0, 0))
+strip.write()

--- a/tutorial.md
+++ b/tutorial.md
@@ -75,6 +75,40 @@ led_show.run()
 
 If you are curious about the inner workings on these LEDs you can find the datasheet [here](https://cdn-shop.adafruit.com/datasheets/APA102.pdf) and the singal source code [here](https://github.com/bytebarista/iot_workshop/blob/master/src/led_lights.py)
 
+### Controlling APA102 LEDs
+
+APA102 LEDs, also known as DotStar LEDs, are individually addressable full-colour RGB LEDs, generally in a string formation. They differ from NeoPixels in that they require two pins to control - both a Clock and Data pin.  They can operate at a much higher data and PWM frequencies than NeoPixels and
+are more suitable for persistence-of-vision effects.
+
+To create an APA102 object do the following::
+
+```
+    >>> import machine, apa102
+    >>> spi = SPI(2, sck=Pin(13), mosi=Pin(4), miso=Pin(12))
+    >>> strip = APA102(spi, 4)
+```
+
+This configures an 4 pixel APA102 strip.
+
+The RGB colour data, as well as a brightness level, is sent to the APA102 in a certain order ``(Red, Green, Blue, Brightness)``.
+
+To set the colour of pixels use::
+
+```
+    >>> strip[0] = (255, 255, 255, 31) # set to white, full brightness
+    >>> strip[1] = (255, 0, 0, 31) # set to red, full brightness
+    >>> strip[2] = (0, 255, 0, 15) # set to green, half brightness
+    >>> strip[3] = (0, 0, 255, 7)  # set to blue, quarter brightness
+```
+
+Use the ``write()`` method to output the colours to the LEDs::
+
+    >>> strip.write()
+
+Demonstration::
+
+[play with apa102 strip](the_pad/demos/apa102_strip.py)
+
 # TouchPad
 
 The ESP32 microcontroller has touch pin functionality:


### PR DESCRIPTION
Implementation of APA102/DotStar LEDs w/ almost same interface as found in micropython for ESP8266 (https://docs.micropython.org/en/latest/esp8266/tutorial/apa102.html). Tweaked their example demo a bit but tried to stay close and consistant.

Updated tutorial but kept the original LED text. Do we want to get rid of it? 

Not sure if we also want a read() method to get the LEDs status but not sure what we would use it for at this point...